### PR TITLE
vtk package issue

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -191,15 +191,15 @@ jobs:
       - name: Display package file list
         run: ls -R
 
-      # - name: Upload to Private PyPi
-      #   run: |
-      #     pip install twine
-      #     python -m twine upload --skip-existing ./**/*.whl
-      #     python -m twine upload --skip-existing ./**/*.tar.gz
-      #   env:
-      #     TWINE_USERNAME: PAT
-      #     TWINE_PASSWORD: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
-      #     TWINE_REPOSITORY_URL: https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload
+      - name: Upload to Private PyPi
+        run: |
+          pip install twine
+          python -m twine upload --skip-existing ./**/*.whl
+          python -m twine upload --skip-existing ./**/*.tar.gz
+        env:
+          TWINE_USERNAME: PAT
+          TWINE_PASSWORD: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
+          TWINE_REPOSITORY_URL: https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload
 
       - name: Upload to Public PyPi
         run: |

--- a/README.rst
+++ b/README.rst
@@ -42,12 +42,24 @@ Installation
 The ``ansys-fluent-visualization`` package currently supports Python 3.7 through Python
 3.10 on Windows and Linux.
 
-If you want to use PyFluent visualization please install the latest from `PyFluent Visualization GitHub
+If you're using Python 3.10, install the vtk package from .whl file
+`here in Windows <https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl>`_ or
+`here in Linux <https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl>`_.
+
+Install the latest release from `PyPI
+<https://pypi.org/project/ansys-fluent-visualization/>`_ with:
+
+.. code:: console
+
+   pip install ansys-fluent-visualization
+
+Alternatively, install the latest from `pyfluent-visualization GitHub
 <https://github.com/pyansys/pyfluent-visualization>`_ via:
 
 .. code:: console
 
    pip install git+https://github.com/pyansys/pyfluent-visualization.git
+
 
 If you plan on doing local "development" of PyFluent with Git, then install
 with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,7 @@ packages = [
 python = ">=3.7,<4.0"
 importlib-metadata = {version = "^4.0", python = "<3.8"}
 ansys-fluent-core = "~=0.10"
-vtk = [
-{ url = "https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" , markers = "python_version > '3.9' and sys_platform == 'linux'"},
-{ url = "https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl" , markers = "python_version > '3.9' and sys_platform != 'linux'"},
-{ version = "9.1.0", python = "<=3.9"   },
-]
+vtk = {version = "9.1.0", python = "<=3.9"}
 ipyvtklink = ">=0.2.2" 
 pyvista = ">=0.33.2"
 pyvistaqt = ">=0.7.0"


### PR DESCRIPTION
```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
         Invalid value for requires_dist. Error: Can't have direct dependency:  
         'vtk @ https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev
         0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ;         
         python_version > "3.9" and sys_platform == "linux"'                    
Error: Process completed with exit code 1.
```
Above is the error during PyPI upload. There seems to be a [restriction](https://peps.python.org/pep-0440/#direct-references) that direct urls are not supported.