### PR TITLE
Zip HTML doc before upload in CI run.

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -149,11 +149,16 @@ jobs:
           DOCS_CNAME: fluentvisualization.docs.pyansys.com
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
+      - name: Zip HTML Documentation before upload
+        run: |
+          sudo apt install zip -y
+          zip -r doc.zip doc/_build/html
+
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:
           name: HTML-Documentation-tag-${{ matrix.image-tag }}
-          path: doc/_build/html
+          path: doc.zip
           retention-days: 7
 
       - name: Deploy


### PR DESCRIPTION
Documentation html files have been zipped before uploading for the github CI run. This saves a lot of time by not requiring to upload large size files.