### PR TITLE
Use the new format to access pathlines data.

### DIFF
--- a/src/ansys/fluent/visualization/post_data_extractor.py
+++ b/src/ansys/fluent/visualization/post_data_extractor.py
@@ -8,10 +8,7 @@ from ansys.fluent.core.post_objects.post_object_definitions import (
     GraphicsDefn,
     PlotDefn,
 )
-from ansys.fluent.core.services.field_data import (
-    _FieldDataConstants,
-    merge_pathlines_data,
-)
+from ansys.fluent.core.services.field_data import _FieldDataConstants
 import numpy as np
 
 
@@ -191,12 +188,11 @@ class FieldDataExtractor:
         try:
             fields = transaction.get_fields()
             pathlines_data = fields[(("type", "pathlines-field"), ("field", field))]
-            data = merge_pathlines_data(pathlines_data, field)
         except Exception as e:
             raise RuntimeError("Error while requesting data from server." + str(e))
         finally:
             obj._post_display()
-        return data
+        return pathlines_data
 
     def _fetch_vector_data(self, obj, *args, **kwargs):
 


### PR DESCRIPTION
This is created with respect to the changes in the core repo - filed_data.py - to access the pathlines data directly instead of merge_pathlines_data