### PR TITLE
Feat/gh pages deployment

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -77,6 +77,8 @@ jobs:
     runs-on: [self-hosted, pyfluent]
     env:
       DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
+      DOCUMENTATION_CNAME: 'visualization.fluent.docs.pyansys.com'
+
     steps:
       - uses: actions/checkout@v3
 
@@ -133,7 +135,6 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
-          DOCS_CNAME: visualization.fluent.docs.pyansys.com
           FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Upload HTML Documentation
@@ -145,7 +146,7 @@ jobs:
 
       - name: Deploy
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: pyansys/actions/doc-deploy-stable@v2
+        uses: pyansys/actions/doc-deploy-stable@v3
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
           cname: ${{ env.DOCUMENTATION_CNAME }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -144,7 +144,7 @@ jobs:
           retention-days: 7
 
       - name: Deploy
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: pyansys/actions/doc-deploy-stable@v2
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -133,30 +133,23 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
-          DOCS_CNAME: fluentvisualization.docs.pyansys.com
+          DOCS_CNAME: visualization.fluent.docs.pyansys.com
           FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-
-      - name: Zip HTML Documentation before upload
-        run: |
-          sudo apt install zip -y
-          zip -r doc.zip doc/_build/html
 
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:
           name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-          path: doc.zip
+          path: doc/_build/html
           retention-days: 7
 
       - name: Deploy
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: pyansys/actions/doc-deploy-stable@v2
         with:
-          repository-name: pyansys/pyfluent-visualization-docs
-          token: ${{ steps.get_workflow_token.outputs.token  }}
-          BRANCH: gh-pages
-          FOLDER: doc/_build/html
-          CLEAN: true
+          doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
 
   build:

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Deploy
         if: matrix.image-tag == 'v23.1.0'
-        uses: pyansys/actions/doc-deploy-stable@v3
+        uses: pyansys/actions/doc-deploy-dev@v3
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
           cname: ${{ env.DOCUMENTATION_CNAME }}

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -8,6 +8,7 @@ on:
 env:
   DOCUMENTATION_CNAME: 'visualization.fluent.docs.pyansys.com'
   DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
+  
 jobs:
   nightly_docs_build:
     runs-on: ubuntu-20.04
@@ -56,7 +57,6 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
-          DOCS_CNAME: dev.visualization.fluent.docs.pyansys.com
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Upload HTML Documentation

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -68,7 +68,7 @@ jobs:
           retention-days: 7
 
       - name: Deploy
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        if: matrix.image-tag == 'v23.1.0'
         uses: pyansys/actions/doc-deploy-stable@v2
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -5,6 +5,9 @@ on:
     - cron:  '0 4 * * *'
   workflow_dispatch:
 
+env:
+  DOCUMENTATION_CNAME: 'visualization.fluent.docs.pyansys.com'
+  DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
 jobs:
   nightly_docs_build:
     runs-on: ubuntu-20.04
@@ -53,15 +56,24 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
-          DOCS_CNAME: dev.fluentvisualization.docs.pyansys.com
+          DOCS_CNAME: dev.visualization.fluent.docs.pyansys.com
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
-      - name: Deploy
-        if: matrix.image-tag == 'v23.1.0'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - name: Upload HTML Documentation
+        uses: actions/upload-artifact@v3
         with:
-          repository-name: pyansys/pyfluent-visualization-dev-docs
-          token: ${{ steps.get_workflow_token.outputs.token }}
-          BRANCH: gh-pages
-          FOLDER: doc/_build/html
-          CLEAN: true
+          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+          path: doc/_build/html
+
+          retention-days: 7
+
+      - name: Deploy
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
+        uses: pyansys/actions/doc-deploy-stable@v2
+        with:
+          doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+
+

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Deploy
         if: matrix.image-tag == 'v23.1.0'
-        uses: pyansys/actions/doc-deploy-stable@v2
+        uses: pyansys/actions/doc-deploy-stable@v3
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
           cname: ${{ env.DOCUMENTATION_CNAME }}

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -68,7 +68,7 @@ jobs:
           retention-days: 7
 
       - name: Deploy
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: pyansys/actions/doc-deploy-stable@v2
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 
 import ansys.fluent.core as pyfluent
-from ansys_sphinx_theme import ansys_favicon, pyansys_logo_black
+from ansys_sphinx_theme import ansys_favicon, pyansys_logo_black, get_version_match
 import numpy as np
 import pyvista
 from sphinx_gallery.sorting import FileNameSortKey
@@ -36,6 +36,9 @@ pyfluent.BUILDING_GALLERY = True
 project = "ansys-fluent-visualization"
 copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "ANSYS Inc."
+
+# Canonical name of the webpage (defined in the ci_cd.yml)
+cname = os.getenv("DOCUMENTATION_CNAME", "visualization.fluent.docs.pyansys.com")
 
 # The short X.Y version
 release = version = __version__
@@ -176,6 +179,11 @@ html_short_title = html_title = "PyFluent-Visualization"
 html_theme = "ansys_sphinx_theme"
 html_logo = pyansys_logo_black
 html_theme_options = {
+    "switcher": {
+                    "json_url":f"https://{cname}/release/versions.json",
+                    "version_match": get_version_match(__version__),
+                },
+    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "github_url": "https://github.com/pyansys/pyfluent-visualization",
     "show_prev_next": False,
     "show_breadcrumbs": True,


### PR DESCRIPTION
Updated the conf.py and workflow files to push the built documentation to the gh-pages branch and enable the multi-version feature. 

Afterwards, will require configuring the CNAME outside of GitHub to deploy and host the docs.