### PR TITLE
Fixed a typo.

### DIFF
--- a/examples/00-postprocessing/post_processing_exhaust_manifold.py
+++ b/examples/00-postprocessing/post_processing_exhaust_manifold.py
@@ -69,7 +69,7 @@ mesh1.show_edges = True
 ###############################################################################
 # Get surfaces list
 # ~~~~~~~~~~~~~~~~~
-# Get the surfaccase list.
+# Get the surfaces list.
 
 mesh1.surfaces_list = [
     "in1",


### PR DESCRIPTION
example contains typo "surfaccase" which has been fixed.