### PR TITLE
Separate fetch and display

### DIFF
--- a/src/ansys/fluent/visualization/matplotlib/matplot_windows_manager.py
+++ b/src/ansys/fluent/visualization/matplotlib/matplot_windows_manager.py
@@ -3,7 +3,7 @@ import itertools
 import multiprocessing as mp
 from typing import Dict, List, Optional, Union
 
-from ansys.fluent.core.fluent_connection import _FluentConnection
+from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.post_objects.post_object_definitions import (
     MonitorDefn,
     PlotDefn,
@@ -38,7 +38,7 @@ class _ProcessPlotterHandle:
             target=self.plotter, args=(plotter_pipe,), daemon=True
         )
         self.plot_process.start()
-        _FluentConnection._monitor_thread.cbs.append(self.close)
+        FluentConnection._monitor_thread.cbs.append(self.close)
 
     def plot(self, data):
         self.plot_pipe.send(data)

--- a/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
@@ -68,7 +68,7 @@ class Mesh(MeshDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id, True)
+        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)
 
 
 class Pathlines(PathlinesDefn):
@@ -95,7 +95,7 @@ class Pathlines(PathlinesDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id, True)
+        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)
 
 
 class Surface(SurfaceDefn):
@@ -133,7 +133,7 @@ class Surface(SurfaceDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id, True)
+        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)
 
 
 class Contour(ContourDefn):
@@ -169,7 +169,7 @@ class Contour(ContourDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id, True)
+        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)
 
 
 class Vector(VectorDefn):
@@ -206,4 +206,4 @@ class Vector(VectorDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id, True)
+        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)

--- a/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
@@ -143,7 +143,7 @@ class Surface(SurfaceDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         overlay : bool, optional
-            If set to ``True``, graphics will be overlaid over existing graphics.
+            Whether to overlay graphics over existing graphics.
             The default is ``False``.
         """
         pyvista_windows_manager.plot(

--- a/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
@@ -169,7 +169,7 @@ class Contour(ContourDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id,  True)
+        pyvista_windows_manager.plot(self, window_id, True)
 
 
 class Vector(VectorDefn):
@@ -206,4 +206,4 @@ class Vector(VectorDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id,  True)
+        pyvista_windows_manager.plot(self, window_id, True)

--- a/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
@@ -226,7 +226,7 @@ class Vector(VectorDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         overlay : bool, optional
-            If set to ``True``, graphics will be overlaid over existing graphics.
+            Whether to overlay graphics over existing graphics.
             The default is ``False``.
         """
         pyvista_windows_manager.plot(

--- a/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
@@ -68,7 +68,7 @@ class Mesh(MeshDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id)
+        pyvista_windows_manager.plot(self, window_id, True)
 
 
 class Pathlines(PathlinesDefn):
@@ -95,7 +95,7 @@ class Pathlines(PathlinesDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id)
+        pyvista_windows_manager.plot(self, window_id, True)
 
 
 class Surface(SurfaceDefn):
@@ -133,7 +133,7 @@ class Surface(SurfaceDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id)
+        pyvista_windows_manager.plot(self, window_id, True)
 
 
 class Contour(ContourDefn):
@@ -169,7 +169,7 @@ class Contour(ContourDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id)
+        pyvista_windows_manager.plot(self, window_id,  True)
 
 
 class Vector(VectorDefn):
@@ -206,4 +206,4 @@ class Vector(VectorDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         """
-        pyvista_windows_manager.plot(self, window_id)
+        pyvista_windows_manager.plot(self, window_id,  True)

--- a/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
@@ -59,7 +59,7 @@ class Mesh(MeshDefn):
     """
 
     @Command
-    def display(self, window_id: Optional[str] = None):
+    def display(self, window_id: Optional[str] = None, overlay: Optional[bool] = False):
         """Display mesh graphics.
 
         Parameters
@@ -67,8 +67,13 @@ class Mesh(MeshDefn):
         window_id : str, optional
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
+        overlay : bool, optional
+            If set to ``True``, graphics will be overlaid over existing graphics.
+            The default is ``False``.
         """
-        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)
+        pyvista_windows_manager.plot(
+            self, window_id=window_id, overlay=overlay, fetch_data=True
+        )
 
 
 class Pathlines(PathlinesDefn):
@@ -86,7 +91,7 @@ class Pathlines(PathlinesDefn):
     """
 
     @Command
-    def display(self, window_id: Optional[str] = None):
+    def display(self, window_id: Optional[str] = None, overlay: Optional[bool] = False):
         """Display mesh graphics.
 
         Parameters
@@ -94,8 +99,13 @@ class Pathlines(PathlinesDefn):
         window_id : str, optional
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
+        overlay : bool, optional
+            If set to ``True``, graphics will be overlaid over existing graphics.
+            The default is ``False``.
         """
-        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)
+        pyvista_windows_manager.plot(
+            self, window_id=window_id, overlay=overlay, fetch_data=True
+        )
 
 
 class Surface(SurfaceDefn):
@@ -124,7 +134,7 @@ class Surface(SurfaceDefn):
     """
 
     @Command
-    def display(self, window_id: Optional[str] = None):
+    def display(self, window_id: Optional[str] = None, overlay: Optional[bool] = False):
         """Display surface graphics.
 
         Parameters
@@ -132,8 +142,13 @@ class Surface(SurfaceDefn):
         window_id : str, optional
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
+        overlay : bool, optional
+            If set to ``True``, graphics will be overlaid over existing graphics.
+            The default is ``False``.
         """
-        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)
+        pyvista_windows_manager.plot(
+            self, window_id=window_id, overlay=overlay, fetch_data=True
+        )
 
 
 class Contour(ContourDefn):
@@ -160,7 +175,7 @@ class Contour(ContourDefn):
     """
 
     @Command
-    def display(self, window_id: Optional[str] = None):
+    def display(self, window_id: Optional[str] = None, overlay: Optional[bool] = False):
         """Display contour graphics.
 
         Parameters
@@ -168,8 +183,13 @@ class Contour(ContourDefn):
         window_id : str, optional
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
+        overlay : bool, optional
+            If set to ``True``, graphics will be overlaid over existing graphics.
+            The default is ``False``.
         """
-        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)
+        pyvista_windows_manager.plot(
+            self, window_id=window_id, overlay=overlay, fetch_data=True
+        )
 
 
 class Vector(VectorDefn):
@@ -197,7 +217,7 @@ class Vector(VectorDefn):
     """
 
     @Command
-    def display(self, window_id: Optional[str] = None):
+    def display(self, window_id: Optional[str] = None, overlay: Optional[bool] = False):
         """Display vector graphics.
 
         Parameters
@@ -205,5 +225,10 @@ class Vector(VectorDefn):
         window_id : str, optional
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
+        overlay : bool, optional
+            If set to ``True``, graphics will be overlaid over existing graphics.
+            The default is ``False``.
         """
-        pyvista_windows_manager.plot(self, window_id=window_id, fetch_data=True)
+        pyvista_windows_manager.plot(
+            self, window_id=window_id, overlay=overlay, fetch_data=True
+        )

--- a/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
@@ -184,7 +184,7 @@ class Contour(ContourDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         overlay : bool, optional
-            If set to ``True``, graphics will be overlaid over existing graphics.
+            Whether to overlay graphics over existing graphics.
             The default is ``False``.
         """
         pyvista_windows_manager.plot(

--- a/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
@@ -100,7 +100,7 @@ class Pathlines(PathlinesDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         overlay : bool, optional
-            If set to ``True``, graphics will be overlaid over existing graphics.
+            Whether to overlay graphics over existing graphics.
             The default is ``False``.
         """
         pyvista_windows_manager.plot(

--- a/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_objects.py
@@ -68,7 +68,7 @@ class Mesh(MeshDefn):
             Window ID. If an ID is not specified, a unique ID is used.
             The default is ``None``.
         overlay : bool, optional
-            If set to ``True``, graphics will be overlaid over existing graphics.
+            Whether to overlay graphics over existing graphics.
             The default is ``False``.
         """
         pyvista_windows_manager.plot(

--- a/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
@@ -79,10 +79,11 @@ class PyVistaWindow(PostWindow):
         }
 
     def set_data(self, data_type: FieldDataType, data: Dict[int, Dict[str, np.array]]):
+        """Set data for graphics."""
         self._data[data_type] = data
 
     def fetch(self):
-        """Plot graphics."""
+        """Fetch data for graphics."""
         if not self.post_object:
             return
         obj = self.post_object
@@ -98,7 +99,7 @@ class PyVistaWindow(PostWindow):
             self._fetch_pathlines(obj)
 
     def render(self):
-        """Plot graphics."""
+        """Render graphics."""
         if not self.post_object:
             return
         obj = self.post_object
@@ -140,7 +141,7 @@ class PyVistaWindow(PostWindow):
             self._visible = True
 
     def plot(self):
-        """Plot graphics."""
+        """Display graphics."""
         self.fetch()
         self.render()
 

--- a/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
@@ -1,4 +1,5 @@
 """Module for pyVista windows management."""
+from enum import Enum
 import itertools
 import threading
 from typing import Dict, List, Optional, Union
@@ -9,13 +10,14 @@ from ansys.fluent.core.utils.generic import AbstractSingletonMeta, in_notebook
 import numpy as np
 import pyvista as pv
 from pyvistaqt import BackgroundPlotter
-from enum import Enum
+
 from ansys.fluent.visualization import get_config
 from ansys.fluent.visualization.post_data_extractor import FieldDataExtractor
 from ansys.fluent.visualization.post_windows_manager import (
     PostWindow,
     PostWindowsManager,
 )
+
 
 class FieldDataType(Enum):
     """Provides surface data types."""
@@ -24,7 +26,8 @@ class FieldDataType(Enum):
     Vectors = 2
     Contours = 3
     Pathlines = 4
-    
+
+
 class PyVistaWindow(PostWindow):
     """Provides for managing PyVista windows."""
 
@@ -46,7 +49,7 @@ class PyVistaWindow(PostWindow):
             else BackgroundPlotter(title=f"PyFluent ({self.id})")
         )
         self.overlay: bool = False
-        self.fetch_data : bool = False        
+        self.fetch_data: bool = False
         self.animate: bool = False
         self.close: bool = False
         self.refresh: bool = False
@@ -74,9 +77,9 @@ class PyVistaWindow(PostWindow):
             "white": [255, 255, 255],
         }
 
-    def set_data(self, data_type:FieldDataType, data: Dict[int, Dict[str, np.array]]):
+    def set_data(self, data_type: FieldDataType, data: Dict[int, Dict[str, np.array]]):
         self._data[data_type] = data
-    
+
     def fetch(self):
         """Plot graphics."""
         if not self.post_object:
@@ -273,7 +276,7 @@ class PyVistaWindow(PostWindow):
 
     def _fetch_contour(self, obj):
         if self._data.get(FieldDataType.Contours) is None or self.fetch_data:
-            self._data[FieldDataType.Contours] = FieldDataExtractor(obj).fetch_data()    
+            self._data[FieldDataType.Contours] = FieldDataExtractor(obj).fetch_data()
 
     def _display_contour(self, obj, plotter: Union[BackgroundPlotter, pv.Plotter]):
         # contour properties
@@ -429,9 +432,8 @@ class PyVistaWindow(PostWindow):
 
     def _fetch_mesh(self, obj):
         if self._data.get(FieldDataType.Meshes) is None or self.fetch_data:
-            self._data[FieldDataType.Meshes] = FieldDataExtractor(obj).fetch_data() 
+            self._data[FieldDataType.Meshes] = FieldDataExtractor(obj).fetch_data()
 
-            
     def _display_mesh(self, obj, plotter: Union[BackgroundPlotter, pv.Plotter]):
         for surface_id, mesh_data in self._data[FieldDataType.Meshes].items():
             if "vertices" not in mesh_data or "faces" not in mesh_data:
@@ -563,7 +565,12 @@ class PyVistaWindowsManager(PostWindowsManager, metaclass=AbstractSingletonMeta)
             if window:
                 window.post_object = object
 
-    def plot(self, object: GraphicsDefn, window_id: Optional[str] = None, fetch_data: Optional[bool] = False) -> None:
+    def plot(
+        self,
+        object: GraphicsDefn,
+        window_id: Optional[str] = None,
+        fetch_data: Optional[bool] = False,
+    ) -> None:
         """Draw a plot.
 
         Parameters
@@ -729,7 +736,9 @@ class PyVistaWindowsManager(PostWindowsManager, metaclass=AbstractSingletonMeta)
             self._post_windows.clear()
             self._condition.notify()
 
-    def _open_and_plot_console(self, obj: object, window_id: str, fetch_data: bool) -> None:
+    def _open_and_plot_console(
+        self, obj: object, window_id: str, fetch_data: bool
+    ) -> None:
         if self._exit_thread:
             return
         with self._condition:

--- a/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
@@ -50,6 +50,7 @@ class PyVistaWindow(PostWindow):
         )
         self.overlay: bool = False
         self.fetch_data: bool = False
+        self.show_window: bool = True
         self.animate: bool = False
         self.close: bool = False
         self.refresh: bool = False
@@ -134,7 +135,7 @@ class PyVistaWindow(PostWindow):
             view_fun()
         else:
             plotter.camera = camera.copy()
-        if not self._visible:
+        if not self._visible and self.show_window:
             plotter.show()
             self._visible = True
 

--- a/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
@@ -486,18 +486,18 @@ class PyVistaWindowsManager(PostWindowsManager, metaclass=AbstractSingletonMeta)
         self._exit_thread: bool = False
         self._app = None
 
-    def get_window(self, window_id: str) -> Union[BackgroundPlotter, pv.Plotter]:
-        """Get the PyVista plotter.
+    def get_window(self, window_id: str) -> PyVistaWindow:
+        """Get the PyVista window.
 
         Parameters
         ----------
         window_id : str
-            Window ID for the plotter.
+            Window ID.
 
         Returns
         -------
-        Union[BackgroundPlotter, pv.Plotter]
-            PyVista plotter.
+        PyVistaWindow
+            PyVista window.
         """
         with self._condition:
             return self._post_windows.get(window_id, None)

--- a/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
@@ -96,15 +96,13 @@ class PyVistaWindow(PostWindow):
         elif obj.__class__.__name__ == "Pathlines":
             self._fetch_pathlines(obj)
 
-    def render(self, overlay=None):
+    def render(self):
         """Plot graphics."""
         if not self.post_object:
             return
         obj = self.post_object
         plotter = self.plotter
         camera = plotter.camera.copy()
-        if overlay is not None:
-            self.overlay = overlay
         if not self.overlay:
             if in_notebook() and self.plotter.theme._jupyter_backend == "pythreejs":
                 plotter.remove_actor(plotter.renderer.actors.copy())
@@ -140,12 +138,10 @@ class PyVistaWindow(PostWindow):
             plotter.show()
             self._visible = True
 
-    def plot(self, overlay=None):
+    def plot(self):
         """Plot graphics."""
-        if overlay is not None:
-            self.overlay = overlay
         self.fetch()
-        self.render(self.overlay)
+        self.render()
 
     # private methods
 
@@ -737,7 +733,7 @@ class PyVistaWindowsManager(PostWindowsManager, metaclass=AbstractSingletonMeta)
             self._condition.notify()
 
     def _open_and_plot_console(
-        self, obj: object, window_id: str, fetch_data: bool
+        self, obj: object, window_id: str, fetch_data: bool = False
     ) -> None:
         if self._exit_thread:
             return

--- a/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
@@ -582,7 +582,7 @@ class PyVistaWindowsManager(PostWindowsManager, metaclass=AbstractSingletonMeta)
         fetch_data : bool, optional
             Whether to fetch data. The default is ``False``.
         overlay : bool, optional
-            If set to `True`, new graphics will be overlaid over existing.
+            Whether to overlay graphics over existing graphics. The default is ``False``.
         Raises
         ------
         RuntimeError

--- a/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
@@ -580,7 +580,7 @@ class PyVistaWindowsManager(PostWindowsManager, metaclass=AbstractSingletonMeta)
             Window ID for the plot. The default is ``None``, in which
             case a unique ID is assigned.
         fetch_data : bool, optional
-            If set to `True`,data will always be fetched.
+            Whether to fetch data. The default is ``False``.
         overlay : bool, optional
             If set to `True`, new graphics will be overlaid over existing.
         Raises

--- a/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
+++ b/src/ansys/fluent/visualization/pyvista/pyvista_windows_manager.py
@@ -4,7 +4,7 @@ import itertools
 import threading
 from typing import Dict, List, Optional, Union
 
-from ansys.fluent.core.fluent_connection import _FluentConnection
+from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.post_objects.post_object_definitions import GraphicsDefn
 from ansys.fluent.core.utils.generic import AbstractSingletonMeta, in_notebook
 import numpy as np
@@ -213,7 +213,7 @@ class PyVistaWindow(PostWindow):
             else:
                 auto_range_on = obj.range.auto_range_on
                 if auto_range_on.global_range():
-                    range = field_info.get_range(obj.field(), False)
+                    range = field_info.get_scalar_fields_range(obj.field(), False)
                 else:
                     range = [np.min(scalar_field), np.max(scalar_field)]
 
@@ -360,7 +360,7 @@ class PyVistaWindow(PostWindow):
                         field_info = obj._api_helper.field_info()
                         plotter.add_mesh(
                             mesh,
-                            clim=field_info.get_range(obj.field(), False),
+                            clim=field_info.get_scalar_fields_range(obj.field(), False),
                             scalars=field,
                             show_edges=obj.show_edges(),
                             scalar_bar_args=scalar_bar_args,
@@ -397,6 +397,7 @@ class PyVistaWindow(PostWindow):
             contour.surfaces_list = [obj._name]
             contour.show_edges = obj.show_edges()
             contour.range.auto_range_on.global_range = True
+            contour.boundary_values = True
             self._fetch_contour(contour)
             del post_session.Contours[dummy_object]
         else:
@@ -419,6 +420,7 @@ class PyVistaWindow(PostWindow):
             contour.surfaces_list = [obj._name]
             contour.show_edges = obj.show_edges()
             contour.range.auto_range_on.global_range = True
+            contour.boundary_values = True
             self._display_contour(contour, plotter)
             del post_session.Contours[dummy_object]
         else:
@@ -582,7 +584,8 @@ class PyVistaWindowsManager(PostWindowsManager, metaclass=AbstractSingletonMeta)
         fetch_data : bool, optional
             Whether to fetch data. The default is ``False``.
         overlay : bool, optional
-            Whether to overlay graphics over existing graphics. The default is ``False``.
+            Whether to overlay graphics over existing graphics.
+            The default is ``False``.
         Raises
         ------
         RuntimeError
@@ -755,8 +758,8 @@ class PyVistaWindowsManager(PostWindowsManager, metaclass=AbstractSingletonMeta)
             self._overlay = overlay
 
         if not self._plotter_thread:
-            if _FluentConnection._monitor_thread:
-                _FluentConnection._monitor_thread.cbs.append(self._exit)
+            if FluentConnection._monitor_thread:
+                FluentConnection._monitor_thread.cbs.append(self._exit)
             self._plotter_thread = threading.Thread(target=self._display, args=())
             self._plotter_thread.start()
 

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -135,7 +135,7 @@ class MockFieldInfo:
     def __init__(self, solver_data):
         self._session_data = solver_data
 
-    def get_range(
+    def get_scalar_fields_range(
         self, field: str, node_value: bool = False, surface_ids: List[int] = []
     ) -> List[float]:
         if not surface_ids:
@@ -152,7 +152,7 @@ class MockFieldInfo:
             maximum = max(range[1], maximum) if maximum else range[1]
         return [minimum, maximum]
 
-    def get_fields_info(self) -> dict:
+    def get_scalar_fields_info(self) -> dict:
         return self._session_data["scalar_fields_info"]
 
     def get_vector_fields_info(self) -> dict:
@@ -281,7 +281,7 @@ def test_contour_object():
     contour1.surfaces_list = contour1.surfaces_list.allowed_values
 
     # Field allowed values should be all fields.
-    assert contour1.field.allowed_values == list(field_info.get_fields_info())
+    assert contour1.field.allowed_values == list(field_info.get_scalar_fields_info())
 
     # Important. Because there is no type checking so following passes.
     contour1.field = [contour1.field.allowed_values[0]]
@@ -328,19 +328,25 @@ def test_contour_object():
         if k in contour1.surfaces_list()
     ]
 
-    range = field_info.get_range(contour1.field(), contour1.node_values(), surfaces_id)
+    range = field_info.get_scalar_fields_range(
+        contour1.field(), contour1.node_values(), surfaces_id
+    )
     assert range[0] == pytest.approx(contour1.range.auto_range_off.minimum())
     assert range[1] == pytest.approx(contour1.range.auto_range_off.maximum())
 
     # Range should adjust to min/max of cell field values.
     contour1.node_values = False
-    range = field_info.get_range(contour1.field(), contour1.node_values(), surfaces_id)
+    range = field_info.get_scalar_fields_range(
+        contour1.field(), contour1.node_values(), surfaces_id
+    )
     assert range[0] == pytest.approx(contour1.range.auto_range_off.minimum())
     assert range[1] == pytest.approx(contour1.range.auto_range_off.maximum())
 
     # Range should adjust to min/max of node field values
     contour1.field = "pressure"
-    range = field_info.get_range(contour1.field(), contour1.node_values(), surfaces_id)
+    range = field_info.get_scalar_fields_range(
+        contour1.field(), contour1.node_values(), surfaces_id
+    )
     assert range[0] == pytest.approx(contour1.range.auto_range_off.minimum())
     assert range[1] == pytest.approx(contour1.range.auto_range_off.maximum())
 
@@ -375,7 +381,7 @@ def test_vector_object():
         if k in vector1.surfaces_list()
     ]
 
-    range = field_info.get_range("velocity-magnitude", False)
+    range = field_info.get_scalar_fields_range("velocity-magnitude", False)
     assert range == pytest.approx(
         [
             vector1.range.auto_range_off.minimum(),
@@ -402,7 +408,7 @@ def test_surface_object():
     surf1.definition.type = "iso-surface"
     iso_surf = surf1.definition.iso_surface
 
-    assert iso_surf.field.allowed_values == list(field_info.get_fields_info())
+    assert iso_surf.field.allowed_values == list(field_info.get_scalar_fields_info())
 
     # Important. Because there is no type checking so following test passes.
     iso_surf.field = [iso_surf.field.allowed_values[0]]
@@ -413,7 +419,7 @@ def test_surface_object():
 
     # Iso surface value should automatically update upon change in field.
     iso_surf.field = "temperature"
-    range = field_info.get_range(iso_surf.field(), True)
+    range = field_info.get_scalar_fields_range(iso_surf.field(), True)
     assert (range[0] + range[1]) / 2.0 == pytest.approx(iso_surf.iso_value())
 
     # Setting out of range should throw exception
@@ -425,7 +431,7 @@ def test_surface_object():
 
     # Iso surface value should automatically update upon change in field.
     iso_surf.field = "pressure"
-    range = field_info.get_range(iso_surf.field(), True)
+    range = field_info.get_scalar_fields_range(iso_surf.field(), True)
     assert (range[0] + range[1]) / 2.0 == pytest.approx(iso_surf.iso_value())
 
     # New surface should be in allowed values for graphics.
@@ -476,7 +482,9 @@ def test_xyplot_object():
 
     p1.surfaces_list = p1.surfaces_list.allowed_values
 
-    assert p1.y_axis_function.allowed_values == list(field_info.get_fields_info())
+    assert p1.y_axis_function.allowed_values == list(
+        field_info.get_scalar_fields_info()
+    )
 
     # Important. Because there is no type checking so following passes.
     p1.y_axis_function = [p1.y_axis_function.allowed_values[0]]


### PR DESCRIPTION
Implemented following changes:

- Separated fetching and rendering. It allows to set data directly from other source e.g. if data is received by streaming.
- Meshes are colored by id.
- Image can be exported as html.
- Graphics can be overlayed over each other,

To set data from another source
---------------------------------------
```
pyvista_windows_manager.open_window(window_id)
active_window = pyvista_windows_manager.get_window(window_id)
active_window.post_object = mesh 
active_window.set_data(FieldDataType.Meshes ,data_from_another_source)  
pyvista_windows_manager.refresh_windows(session_id, [window_id])
```

To Overlay
------------
```
mesh1.display("w1")
contour1.display("w1",overlay=true)
```
Temperature contour overlayed over mesh
_____________________________________________
![overlay](https://user-images.githubusercontent.com/95020968/228514208-81118243-fc87-41e0-b16b-15e00570d7a7.png)

To Export as html
--------------------

```
set_config(blocking=True, set_view_on_display="isometric")
pyvista_windows_manager.open_window("w1")
active_window = pyvista_windows_manager.get_window("w1")
active_window.show_window = False 
active_window.post_object = mesh1
active_window.plot()
plotter= pyvista_windows_manager.get_plotter("w1")
plotter.export_html('manifold.html',  backend='panel')
```
![html](https://user-images.githubusercontent.com/95020968/228522574-200ff307-3e16-41a7-9892-79501e74193a.png)