### PR TITLE
pyvista vulnerability fixed in version 0.39.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ python = ">=3.7,<4.0"
 importlib-metadata = {version = "^4.0", python = "<3.8"}
 ansys-fluent-core = "~=0.14.dev0"
 vtk = {version = ">=9.0.3", python = "<=3.9"}
-pyvista = ">=0.33.2"
+pyvista = ">=0.39.0"
 pyvistaqt = ">=0.7.0"
 pyside6 = ">=6.2.3"
 matplotlib = ">=3.5.1"

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -11,5 +11,5 @@ sphinx-gallery==0.11.1
 sphinx-notfound-page==0.8.3
 sphinxcontrib-websupport==1.2.4
 sphinxemoji==0.2.0
-pyvista>=0.33.2
+pyvista>=0.39.0
 matplotlib>=3.5.1


### PR DESCRIPTION
Related to this: https://github.com/pyansys/pyfluent/issues/1552

As identified by akaszynski, there is also a new VTK version in the works that fixes another vulnerability on zlib (https://gitlab.kitware.com/vtk/vtk/-/issues/18962). Need to wait until that one is released to update this here as well.