### PR TITLE
build: unblock PyFluent compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
 importlib-metadata = {version = "^4.0", python = "<3.9"}
-ansys-fluent-core = ">=0.35.0,<0.40.0"
+ansys-fluent-core = "~=0.35.0"
 pyvista = ">=0.44.0"
 matplotlib = ">=3.6.0"
 pyvistaqt = { version = "~=0.11.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
 importlib-metadata = {version = "^4.0", python = "<3.9"}
-ansys-fluent-core = "~=0.35.0"
+ansys-fluent-core = ">=0.35.0"
 pyvista = ">=0.44.0"
 matplotlib = ">=3.6.0"
 pyvistaqt = { version = "~=0.11.1", optional = true }


### PR DESCRIPTION
Why not unblocking the upper limit on PyFluent? It should be feasible that way to install the dev version of pyfluent-visualization with any PyFluent version above 0.35.X that way... if at any point there are breaking changes with PyFluent, we can move the lower limit upwards -- but otherwise it is very inconvenient for users attempting to install from source directly.