### PR TITLE
fix: Broken import paths w.r.t. PyFluent v0.41.0

### DIFF
--- a/examples/00-post_processing/post_processing.py
+++ b/examples/00-post_processing/post_processing.py
@@ -72,7 +72,7 @@ from ansys.fluent.visualization import (
     config,
 )
 
-pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
+pyfluent.CONTAINER_MOUNT_PATH = pyfluent.config.examples_path
 
 config.interactive = False
 config.view = "isometric"
@@ -292,8 +292,8 @@ plot_window.add_plot(residual, position=(0, 1))
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Solve and plot solution monitors.
 
-solver_session.solution.initialization.hybrid_initialize()
-solver_session.solution.run_calculation.iterate(iter_count=50)
+solver_session.settings.solution.initialization.hybrid_initialize()
+solver_session.settings.solution.run_calculation.iterate(iter_count=50)
 
 mass_bal_rplot = Monitor(solver=solver_session, monitor_set_name="mass-bal-rplot")
 plot_window.add_plot(mass_bal_rplot, position=(1, 0))

--- a/examples/00-post_processing/post_processing_context_manager.py
+++ b/examples/00-post_processing/post_processing_context_manager.py
@@ -81,7 +81,7 @@ from ansys.fluent.visualization import (
     config,
 )
 
-pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
+pyfluent.CONTAINER_MOUNT_PATH = pyfluent.config.examples_path
 
 config.interactive = False
 config.view = "isometric"
@@ -226,8 +226,8 @@ with using(solver_session):
     residual = Monitor(monitor_set_name="residual")
     plot_window.add_plot(residual, position=(0, 1))
 
-    solver_session.solution.initialization.hybrid_initialize()
-    solver_session.solution.run_calculation.iterate(iter_count=50)
+    solver_session.settings.solution.initialization.hybrid_initialize()
+    solver_session.settings.solution.run_calculation.iterate(iter_count=50)
 
     mass_bal_rplot = Monitor(monitor_set_name="mass-bal-rplot")
     plot_window.add_plot(mass_bal_rplot, position=(1, 0))

--- a/examples/00-post_processing/post_processing_plotter_apis.py
+++ b/examples/00-post_processing/post_processing_plotter_apis.py
@@ -70,7 +70,7 @@ from ansys.fluent.visualization import (
     config,
 )
 
-pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
+pyfluent.CONTAINER_MOUNT_PATH = pyfluent.config.examples_path
 
 config.interactive = False
 config.view = "isometric"

--- a/examples/00-post_processing/post_processing_plotter_apis_context_manager.py
+++ b/examples/00-post_processing/post_processing_plotter_apis_context_manager.py
@@ -70,7 +70,7 @@ from ansys.fluent.visualization import (
     config,
 )
 
-pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
+pyfluent.CONTAINER_MOUNT_PATH = pyfluent.config.examples_path
 
 config.interactive = False
 config.view = "isometric"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
 importlib-metadata = {version = "^4.0", python = "<3.9"}
-ansys-fluent-core = ">=0.35.0"
+ansys-fluent-core = ">=0.41.0"
 pyvista = ">=0.44.0"
 matplotlib = ">=3.6.0"
 pyvistaqt = { version = "~=0.11.1", optional = true }

--- a/src/ansys/fluent/interface/post_objects/meta.py
+++ b/src/ansys/fluent/interface/post_objects/meta.py
@@ -254,7 +254,9 @@ class PyLocalBaseMeta(type):
         attrs["root"] = property(lambda self: self.get_root())
         attrs["path"] = property(lambda self: self.get_path())
         attrs["session"] = property(lambda self: self.get_session())
-        attrs["field_data"] = property(lambda self: self.get_session().fields.field_data)
+        attrs["field_data"] = property(
+            lambda self: self.get_session().fields.field_data
+        )
         attrs["monitors"] = property(lambda self: self.get_session().monitors)
         attrs["session_handle"] = property(lambda self: self.get_session_handle())
         return super(PyLocalBaseMeta, cls).__new__(cls, name, bases, attrs)

--- a/src/ansys/fluent/interface/post_objects/meta.py
+++ b/src/ansys/fluent/interface/post_objects/meta.py
@@ -254,7 +254,7 @@ class PyLocalBaseMeta(type):
         attrs["root"] = property(lambda self: self.get_root())
         attrs["path"] = property(lambda self: self.get_path())
         attrs["session"] = property(lambda self: self.get_session())
-        attrs["field_data"] = property(lambda self: self.get_session().field_data)
+        attrs["field_data"] = property(lambda self: self.get_session().fields.field_data)
         attrs["monitors"] = property(lambda self: self.get_session().monitors)
         attrs["session_handle"] = property(lambda self: self.get_session_handle())
         return super(PyLocalBaseMeta, cls).__new__(cls, name, bases, attrs)

--- a/src/ansys/fluent/interface/post_objects/post_helper.py
+++ b/src/ansys/fluent/interface/post_objects/post_helper.py
@@ -60,7 +60,7 @@ class PostAPIHelper:
             return local_surface_name.lower()
 
         def _get_api_handle(self):
-            return self.obj.get_root().session.results.surfaces
+            return self.obj.get_root().session.settings.results.surfaces
 
         def _delete_if_exists_on_server(self):
             field_data = self.obj._api_helper.field_data()

--- a/src/ansys/fluent/interface/post_objects/post_objects_container.py
+++ b/src/ansys/fluent/interface/post_objects/post_objects_container.py
@@ -242,8 +242,8 @@ class Graphics(Container):
             outline_mesh = meshes[outline_mesh_id]
             outline_mesh.surfaces = [
                 k
-                for k, v in outline_mesh._api_helper.field_info()
-                .get_surfaces_info()
+                for k, v in outline_mesh._api_helper._field_info()
+                ._get_surfaces_info()
                 .items()
                 if v["type"] == "zone-surf" and v["zone_type"] != "interior"
             ]

--- a/src/ansys/fluent/visualization/containers.py
+++ b/src/ansys/fluent/visualization/containers.py
@@ -24,7 +24,7 @@
 
 import warnings
 
-from ansys.fluent.core.field_data_interfaces import _to_field_name_str
+from ansys.fluent.core.fields.live_field_data import _to_field_name_str
 from ansys.fluent.core.utils.context_managers import _get_active_session
 from ansys.units import VariableDescriptor
 

--- a/src/ansys/fluent/visualization/contour.py
+++ b/src/ansys/fluent/visualization/contour.py
@@ -41,12 +41,8 @@ class Contour:
         """
         Check field and surface names.
         """
-        allowed_fields = (
-            solver.field_data.get_scalar_field_data.field_name.allowed_values()
-        )
-        allowed_surfaces = (
-            solver.field_data.get_scalar_field_data.surface_name.allowed_values()
-        )
+        allowed_fields = solver.fields.field_data.scalar_fields.allowed_values()
+        allowed_surfaces = solver.fields.field_data.surfaces.allowed_values()
         if self.field not in allowed_fields:
             raise ValueError(
                 f"{self.field} is not valid field. Valid fields are {allowed_fields}"

--- a/src/ansys/fluent/visualization/graphics/graphics_windows_manager.py
+++ b/src/ansys/fluent/visualization/graphics/graphics_windows_manager.py
@@ -291,7 +291,7 @@ class GraphicsWindow(VisualizationWindow):
             )
 
     def _display_vector(self, obj, obj_dict):
-        field_data = obj.session.field_data
+        field_data = obj.session.fields.field_data
         vectors_of = obj.vectors_of()
         # scalar bar properties
         try:
@@ -571,7 +571,7 @@ class GraphicsWindow(VisualizationWindow):
                 auto_range_on = obj.range.auto_range_on
                 if auto_range_on.global_range():
                     if filled:
-                        field_data = obj.session.field_data
+                        field_data = obj.session.fields.field_data
                         _mesh_dict = {
                             "data": mesh,
                             "clim": field_data.scalar_fields.range(obj.field(), False),

--- a/src/ansys/fluent/visualization/post_data_extractor.py
+++ b/src/ansys/fluent/visualization/post_data_extractor.py
@@ -25,7 +25,7 @@
 import itertools
 from typing import Dict
 
-from ansys.fluent.core.field_data_interfaces import (
+from ansys.fluent.core.fields.field_data_interfaces import (
     PathlinesFieldDataRequest,
     ScalarFieldDataRequest,
     SurfaceDataType,
@@ -150,8 +150,6 @@ class FieldDataExtractor:
             surfaces=obj.surfaces(),
             data_types=[SurfaceDataType.Vertices, SurfaceDataType.FacesConnectivity],
             flatten_connectivity=True,
-            *args,
-            **kwargs,
         )
         scalar_request = ScalarFieldDataRequest(
             field_name=field,

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -25,7 +25,7 @@ import pickle
 import sys
 from typing import Dict, List, Optional, Union
 
-from ansys.fluent.core.field_data_interfaces import SurfaceDataType
+from ansys.fluent.core.fields.field_data_interfaces import SurfaceDataType
 import numpy as np
 import pytest
 


### PR DESCRIPTION
Due to the recent updates in PyFluent, some of the import paths were broken that has been corrected as part of this PR.
Some deprecated paths have been updated as well.